### PR TITLE
Allow optional identifier in NSE FNO regex

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -67,7 +67,7 @@ const mergedSummary = {
 // 🔍 Extractor logic
 function extractNSEFNO(text) {
   const pattern =
-    /NSE FNO\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(-?\d+\.\d+)\s+(-?\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)/;
+    /NSE\s*FNO(?:\s*-\s*\w+)?\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(-?\d+\.\d+)\s+(-?\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)/;
 
   const match = text.match(pattern);
 


### PR DESCRIPTION
## Summary
- allow optional `- NCL` (or similar identifier) between `NSEFNO` and numeric columns when extracting NSE FNO data

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node` snippet to validate `extractNSEFNO` with `NSEFNO - NCL` input

------
https://chatgpt.com/codex/tasks/task_e_68af4dc85b908320b801b1b6f33a6f5d