### PR TITLE
Process cron dates individually with PDF check

### DIFF
--- a/.github/workflows/daily-cron-job.yml
+++ b/.github/workflows/daily-cron-job.yml
@@ -32,8 +32,10 @@ jobs:
             curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -o artifact.zip \
               "https://api.github.com/repos/${{ github.repository }}/actions/artifacts/$ARTIFACT_ID/zip"
-            
+
             unzip artifact.zip
+            mv row-tracker/* .
+            rm -rf row-tracker artifact.zip
           fi
         shell: bash
 
@@ -47,45 +49,77 @@ jobs:
 
       - name: Install dependencies
         run: npm install
+      
+      - name: Determine dates to process
+        id: dates
+        run: |
+          > dates.txt
+          if [ -f row_tracker_updated.json ]; then
+            LAST_DATE=$(jq -r '.lastUpdatedRow' row_tracker_updated.json)
+          else
+            LAST_DATE=$(date -I -d "yesterday")
+          fi
+          START=$(date -I -d "$LAST_DATE + 1 day")
+          END=$(date -I)
+          d=$START
+          while [ "$(date -d "$d" +%s)" -le "$(date -d "$END" +%s)" ]; do
+            echo "$d" >> dates.txt
+            d=$(date -I -d "$d + 1 day")
+          done
+          cat dates.txt
 
       - name: Run Fetch and Parse
-        run: npm run fetch && npm run parse
-        env:
-          EMAILS: ${{ secrets.EMAILS }}
-          PASSWORDS: ${{ secrets.PASSWORDS }}
-          ACCOUNT_IDS: ${{ secrets.ACCOUNT_IDS }}
-          PDF_PASSWORDS: ${{ secrets.PDF_PASSWORDS }}
+        run: |
+          while read DATE; do
+            echo "Processing $DATE"
+            rm -rf data daily_summary.json
+            mkdir -p data
+            EMAILS='${{ secrets.EMAILS }}' PASSWORDS='${{ secrets.PASSWORDS }}' \
+            ACCOUNT_IDS='${{ secrets.ACCOUNT_IDS }}' PDF_PASSWORDS='${{ secrets.PDF_PASSWORDS }}' \
+            TARGET_DATE=$DATE npm run fetch && TARGET_DATE=$DATE npm run parse
+            mv data "data-$DATE"
+            mv daily_summary.json "daily_summary-$DATE.json"
+          done < dates.txt
 
       - name: Check for PDF files and exit if none
-        id: check_pdfs
         run: |
-          count=$(find ./data -type f -name '*_decrypted.pdf' | wc -l)
-          if [ "$count" -eq 0 ]; then
-            echo "📭 No decrypted PDF files found. Stopping workflow successfully."
+          > valid_dates.txt
+          processed_any=false
+          while read DATE; do
+            count=$(find "data-$DATE" -type f -name '*_decrypted.pdf' | wc -l)
+            if [ "$count" -eq 0 ]; then
+              echo "📭 No decrypted PDF files found for $DATE."
+              continue
+            fi
+            echo "$DATE" >> valid_dates.txt
+            processed_any=true
+          done < dates.txt
+          if [ "$processed_any" = false ]; then
+            echo "No decrypted PDFs found for any date. Exiting."
             exit 0
-          else
-            echo "✅ Decrypted PDF files found: $count"
-            echo "found_pdfs=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Update Google Sheet
-        if: steps.check_pdfs.outputs.found_pdfs == 'true'
-        run: npm run sheet
-        env:
-          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
-          GOOGLE_SHEET_ID: ${{ secrets.GOOGLE_SHEET_ID }}
-          SHEET_GID: ${{ secrets.SHEET_GID }}
-          SHEET_NAME: ${{ secrets.SHEET_NAME }}
+        run: |
+          while read DATE; do
+            mv "data-$DATE" data
+            mv "daily_summary-$DATE.json" daily_summary.json
+            GOOGLE_CREDENTIALS='${{ secrets.GOOGLE_CREDENTIALS }}' \
+            GOOGLE_SHEET_ID='${{ secrets.GOOGLE_SHEET_ID }}' \
+            SHEET_GID='${{ secrets.SHEET_GID }}' SHEET_NAME='${{ secrets.SHEET_NAME }}' \
+            TARGET_DATE=$DATE npm run sheet
+            rm -rf data daily_summary.json
+          done < valid_dates.txt
 
-      - name: Upload updated row_tracker.json as artifact
-        if: steps.check_pdfs.outputs.found_pdfs == 'true'
+      - name: Upload updated row tracker artifacts
         uses: actions/upload-artifact@v4
         with:
           name: row-tracker
-          path: row_tracker.json
+          path: |
+            row_tracker.json
+            row_tracker_updated.json
 
       - name: Delete old artifacts
-        if: steps.check_pdfs.outputs.found_pdfs == 'true'
         uses: c-hive/gha-remove-artifacts@v1
         with:
           age: "2 day"

--- a/fetchMail.js
+++ b/fetchMail.js
@@ -5,8 +5,13 @@ const fs = require("fs");
 const path = require("path");
 const { execSync } = require("child_process");
 
-// ⏲️ 24-hour window
-const dateSince = new Date(Date.now() - 24 * 60 * 60 * 1000);
+// 🎯 Determine which date to process
+// If TARGET_DATE env var is provided (YYYY-MM-DD), use that.
+// Otherwise default to yesterday.
+const targetDateStr = process.env.TARGET_DATE;
+const dateSince = targetDateStr
+  ? new Date(targetDateStr)
+  : new Date(Date.now() - 24 * 60 * 60 * 1000);
 const formattedDate = dateSince.toISOString().slice(0, 10);
 
 // 📁 Ensure 'data' folder exists
@@ -74,9 +79,7 @@ async function processAccount(account) {
       openInbox((err, box) => {
         if (err) return reject(err);
 
-        const formattedDateForSubject = new Date(
-          Date.now() - 24 * 60 * 60 * 1000
-        )
+        const formattedDateForSubject = dateSince
           .toLocaleDateString("en-GB")
           .split("/")
           .join("-");

--- a/updateSheet.js
+++ b/updateSheet.js
@@ -97,11 +97,13 @@ async function updateGoogleSheet() {
       data?.total?.final_net +
       data?.total?.net_brokerage;
 
-    const yesterday = new Date();
-    yesterday.setDate(yesterday.getDate() - 1);
+    // Allow overriding the date via TARGET_DATE env variable
+    const targetDate = process.env.TARGET_DATE
+      ? new Date(process.env.TARGET_DATE)
+      : new Date(Date.now() - 24 * 60 * 60 * 1000);
 
-    const dayName = yesterday.toLocaleDateString("en-GB", { weekday: "long" });
-    const dateFormatted = yesterday.toLocaleDateString("en-GB", {
+    const dayName = targetDate.toLocaleDateString("en-GB", { weekday: "long" });
+    const dateFormatted = targetDate.toLocaleDateString("en-GB", {
       day: "numeric",
       month: "short",
       year: "2-digit",
@@ -163,10 +165,19 @@ async function updateGoogleSheet() {
 
     console.log("✅ Sheet updated successfully!");
 
-    // --- Step 9: Save new lastUpdatedRow to row_tracker.json
+    // --- Step 9: Save trackers with the latest info
     fs.writeFileSync(
       "row_tracker.json",
       JSON.stringify({ lastUpdatedRow: newRow }, null, 2),
+      "utf-8"
+    );
+    fs.writeFileSync(
+      "row_tracker_updated.json",
+      JSON.stringify(
+        { lastUpdatedRow: targetDate.toISOString().slice(0, 10) },
+        null,
+        2
+      ),
       "utf-8"
     );
   } catch (error) {


### PR DESCRIPTION
## Summary
- loop through pending dates and stash outputs by date
- skip sheet updates when no decrypted PDFs are produced
- update sheet only for dates with PDFs, then upload row trackers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b817380f2c832087901ff686f2244e