### PR TITLE
Improve daily cron job date tracking

### DIFF
--- a/.github/workflows/daily-cron-job.yml
+++ b/.github/workflows/daily-cron-job.yml
@@ -48,6 +48,34 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Determine dates to process
+        run: |
+          TODAY=$(date -u +%Y-%m-%d)
+          if [ -f row_tracker.json ]; then
+            LAST_DATE=$(jq -r '.lastProcessedDate' row_tracker.json)
+            if [ "$LAST_DATE" = "null" ]; then
+              LAST_DATE="$TODAY"
+            fi
+          else
+            LAST_DATE="$TODAY"
+          fi
+
+          current=$(date -u -d "$LAST_DATE +1 day" +%Y-%m-%d)
+          : > dates.txt
+          while [ "$(date -u -d "$current" +%s)" -le "$(date -u -d "$TODAY" +%s)" ]; do
+            echo "$current" >> dates.txt
+            current=$(date -u -d "$current +1 day" +%Y-%m-%d)
+          done
+
+          if [ -s dates.txt ]; then
+            NEW_LAST_DATE=$(tail -n 1 dates.txt)
+          else
+            NEW_LAST_DATE="$LAST_DATE"
+          fi
+
+          echo "{\"lastProcessedDate\": \"$NEW_LAST_DATE\"}" > row_tracker_updated.json
+        shell: bash
+
       - name: Run Fetch and Parse
         run: npm run fetch && npm run parse
         env:

--- a/row_tracker_updated.json
+++ b/row_tracker_updated.json
@@ -1,0 +1,3 @@
+{
+  "lastProcessedDate": "2025-08-29"
+}


### PR DESCRIPTION
## Summary
- Determine dates to process using UTC-aware loop in daily-cron-job workflow
- Track last processed date via committed row_tracker_updated.json

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b92a098b68832083490554673c5493