### PR TITLE
Include tomorrow in gap date processing

### DIFF
--- a/checkDates.js
+++ b/checkDates.js
@@ -67,13 +67,15 @@ async function processMissingDates() {
 
     if (!missingDates.length) {
       console.log('No missing days.');
-      return;
+    } else {
+      console.log('Missing dates:');
+      missingDates.forEach((d) => console.log(formatForSheet(d)));
     }
 
-    console.log('Missing dates:');
-    missingDates.forEach((d) => console.log(formatForSheet(d)));
-
     const isoDates = missingDates.map((d) => d.toISOString().slice(0, 10));
+    const tomorrow = new Date(today);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    isoDates.push(tomorrow.toISOString().slice(0, 10));
     fs.writeFileSync('gap_dates.txt', isoDates.join('\n'), 'utf-8');
   } catch (err) {
     console.error('Error checking last date:', err);


### PR DESCRIPTION
## Summary
- have check-dates script write tomorrow's date to `gap_dates.txt`
- simplify workflow by removing redundant step

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b9903bc7488320bfae7a4e2b7602d8