### PR TITLE
Refactor to multi-broker support with pluggable extractors

### DIFF
--- a/.github/workflows/daily-cron-job.yml
+++ b/.github/workflows/daily-cron-job.yml
@@ -79,10 +79,7 @@ jobs:
           done < gap_dates.txt
           echo "updated=$updated" >> $GITHUB_ENV
         env:
-          EMAILS: ${{ secrets.EMAILS }}
-          PASSWORDS: ${{ secrets.PASSWORDS }}
-          ACCOUNT_IDS: ${{ secrets.ACCOUNT_IDS }}
-          PDF_PASSWORDS: ${{ secrets.PDF_PASSWORDS }}
+          BROKER_ACCOUNTS_JSON: ${{ secrets.BROKER_ACCOUNTS_JSON }}
           GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
           GOOGLE_SHEET_ID: ${{ secrets.GOOGLE_SHEET_ID }}
           SHEET_GID: ${{ secrets.SHEET_GID }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ TARGET_DATE=2025-04-30 npm run sheet
 
 ## Architecture
 
-This is a Node.js automation pipeline that processes daily equity/FNO contract notes from **Finvasia (Shoonya)** and records P&L summaries into a Google Sheet. It runs on a daily GitHub Actions schedule. Support for additional brokers (e.g. Angel One) is planned — see the broker-specific sections below.
+This is a Node.js automation pipeline that processes daily equity/FNO contract notes from multiple brokers (currently **Finvasia / Shoonya** and **Angel One**) and records P&L summaries into a Google Sheet. It runs on a daily GitHub Actions schedule.
 
 ### Pipeline Flow
 
@@ -38,26 +38,51 @@ Gmail (IMAP) → fetchMail.js → data/*.pdf (encrypted)
                         updateSheet.js → Google Sheet row
 ```
 
-**`fetchMail.js`** — Connects to each Gmail account over IMAP, searches for emails whose subject matches the Finvasia format `Combined Contract Note for {accountId} {dd-mm-yyyy}`, saves PDF attachments to `data/`, then decrypts them using the system `qpdf` binary with a per-account password from `PDF_PASSWORDS`. **Broker-specific:** the subject pattern (line 84) is hardcoded to Finvasia and must be parameterised when adding other brokers.
+**`brokers/`** — Per-broker plugins. Each plugin exports `subject(accountId, date)` (the IMAP `SUBJECT` search string for that broker's contract-note emails) and `extract(text)` (returns `{ payin_payout_obligation, final_net, net_brokerage }` from decrypted PDF text). `brokers/index.js` is the registry plus the `BROKER_ACCOUNTS_JSON` config loader and the filename helpers (`makeFileName` / `parseFileName`).
 
-**`parser.js`** — Reads all `*_decrypted.pdf` files from `data/`, extracts the NSE FNO summary line using a regex tuned to Finvasia's PDF table layout, and writes `daily_summary.json` with per-account and total values for `payin_payout_obligation`, `final_net`, and `net_brokerage`. **Broker-specific:** the `extractNSEFNO` regex (line 70) matches Finvasia's column order and must be extended with a per-broker extractor when adding other brokers.
+**`fetchMail.js`** — Loads `BROKER_ACCOUNTS_JSON`, opens **one IMAP connection per email**, then iterates the broker accounts inside that mailbox. For each account it runs the broker-specific subject search, saves attachments as `<safeEmail>__<broker>__<accountId>__<originalName>.pdf`, and decrypts via the system `qpdf` binary using `pdfPassword` from the same account entry.
 
-**`checkDates.js`** — Reads `row_tracker.json` for the last-updated sheet row, fetches the date in column C of that row from the Google Sheet, and writes `gap_dates.txt` listing all missing trading dates plus tomorrow. The CI workflow loops over this file to backfill gaps.
+**`parser.js`** — Reads all `*_decrypted.pdf` files from `data/`, parses the embedded `<broker>` and `<accountId>` from the filename, dispatches to the broker plugin's `extract`, and writes `daily_summary.json` with per-account and total values.
 
-**`updateSheet.js`** — Reads `daily_summary.json`, resolves the next empty row via `row_tracker.json` (falling back to the sheet itself), inserts a new row with serial number / day name / date / per-account P&L values, and copies formula columns from the previous row. Persists the new row number to `row_tracker.json`.
+**`checkDates.js`** — Reads `row_tracker.json` for the last-updated sheet row, fetches the date in column C of that row from the Google Sheet, and writes `gap_dates.txt` listing all missing trading dates plus tomorrow. The CI workflow loops over this file to backfill gaps. Broker-agnostic.
+
+**`updateSheet.js`** — Reads `daily_summary.json`, resolves the next empty row via `row_tracker.json` (falling back to the sheet itself), and inserts a new row with serial number / day name / date / per-account P&L values. Account → column order is determined by flattening `BROKER_ACCOUNTS_JSON` in declaration order. Formula columns from the previous row are copied forward.
 
 **`row_tracker.json`** — Persisted between CI runs as a GitHub Actions artifact named `row-tracker`. It stores `{ "lastUpdatedRow": N }` to avoid a live sheet read on every run.
 
-### Multi-Account Support
+### Config: `BROKER_ACCOUNTS_JSON`
 
-`EMAILS`, `PASSWORDS`, `ACCOUNT_IDS`, and `PDF_PASSWORDS` are comma-separated lists of equal length. Each index represents one brokerage account. `parser.js` matches filenames by account ID; `updateSheet.js` maps account IDs to columns in the sheet in the order they appear in `ACCOUNT_IDS`.
+A single env var holds a JSON array of mailboxes. Each mailbox has one Gmail login and one or more broker accounts attached to it (1 email → N accounts → 1 broker per account):
+
+```json
+[
+  {
+    "email": "user1@gmail.com",
+    "emailPassword": "gmail-app-password-1",
+    "accounts": [
+      { "broker": "finvasia", "accountId": "FA1234", "pdfPassword": "pdf-pwd-1" },
+      { "broker": "angelone",  "accountId": "R59799620", "pdfPassword": "pdf-pwd-2" }
+    ]
+  },
+  {
+    "email": "user2@gmail.com",
+    "emailPassword": "gmail-app-password-2",
+    "accounts": [
+      { "broker": "finvasia", "accountId": "FA9999", "pdfPassword": "pdf-pwd-3" }
+    ]
+  }
+]
+```
+
+The flattened account order (mailbox-by-mailbox, account-by-account) defines the Google Sheet column order — keep it stable across runs.
 
 ### Adding a New Broker
 
-Two files need broker-specific changes:
+1. Create `brokers/<name>.js` exporting `subject(accountId, date)` and `extract(text)`. Use `finvasia.js` and `angelone.js` as templates.
+2. Register it in `brokers/index.js` by adding it to the `BROKERS` map.
+3. Reference it in `BROKER_ACCOUNTS_JSON` with `"broker": "<name>"`.
 
-- **`fetchMail.js` line 84** — add a subject template per broker type and select it based on a `BROKER_TYPES` env var (comma-separated, same length as `EMAILS`).
-- **`parser.js` `extractNSEFNO`** — add a broker-specific extractor function and dispatch to it based on the account's broker type. The rest of the pipeline (`updateSheet.js`, `checkDates.js`, `row_tracker.json`) is already broker-agnostic.
+The rest of the pipeline (`fetchMail.js`, `parser.js`, `updateSheet.js`, `checkDates.js`, `row_tracker.json`) needs no changes.
 
 ### Components
 
@@ -67,10 +92,7 @@ Two files need broker-specific changes:
 
 | Variable | Description |
 |---|---|
-| `EMAILS` | Comma-separated Gmail addresses |
-| `PASSWORDS` | Gmail app passwords (same order as EMAILS) |
-| `ACCOUNT_IDS` | Broker account IDs (same order) |
-| `PDF_PASSWORDS` | Per-account PDF decryption passwords (same order) |
+| `BROKER_ACCOUNTS_JSON` | JSON array of mailboxes, each with `email`, `emailPassword`, and `accounts[]` (each account has `broker`, `accountId`, `pdfPassword`). See **Config** section above. |
 | `GOOGLE_CREDENTIALS` | Base64-encoded Google service account JSON |
 | `GOOGLE_SHEET_ID` | Google Sheet ID from URL |
 | `SHEET_GID` | Numeric GID of the target tab |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Gmail (IMAP) → fetchMail.js → data/*.pdf (encrypted)
 
 **`checkDates.js`** — Reads `row_tracker.json` for the last-updated sheet row, fetches the date in column C of that row from the Google Sheet, and writes `gap_dates.txt` listing all missing trading dates plus tomorrow. The CI workflow loops over this file to backfill gaps. Broker-agnostic.
 
-**`updateSheet.js`** — Reads `daily_summary.json`, resolves the next empty row via `row_tracker.json` (falling back to the sheet itself), and inserts a new row with serial number / day name / date / per-account P&L values. Account → column order is determined by flattening `BROKER_ACCOUNTS_JSON` in declaration order. Formula columns from the previous row are copied forward.
+**`updateSheet.js`** — Reads `daily_summary.json`, resolves the next empty row via `row_tracker.json` (falling back to the sheet itself), inserts a new row, copies all formulas from the previous row via `PASTE_FORMULA`, then overwrites columns A–C (serial / day / date) and a 5-column block per account at the `sheetStartColumn` declared in `BROKER_ACCOUNTS_JSON`. The 5 columns are: `payin_payout_obligation`, `net_brokerage`, `other_charges`, `total_charges` (= brokerage + other_charges), `final_net`.
 
 **`row_tracker.json`** — Persisted between CI runs as a GitHub Actions artifact named `row-tracker`. It stores `{ "lastUpdatedRow": N }` to avoid a live sheet read on every run.
 
@@ -60,21 +60,31 @@ A single env var holds a JSON array of mailboxes. Each mailbox has one Gmail log
     "email": "user1@gmail.com",
     "emailPassword": "gmail-app-password-1",
     "accounts": [
-      { "broker": "finvasia", "accountId": "FA1234", "pdfPassword": "pdf-pwd-1" },
-      { "broker": "angelone",  "accountId": "R59799620", "pdfPassword": "pdf-pwd-2" }
+      { "broker": "finvasia", "accountId": "FA1234", "pdfPassword": "pdf-pwd-1", "sheetStartColumn": "D" },
+      { "broker": "angelone",  "accountId": "R59799620", "pdfPassword": "pdf-pwd-2", "sheetStartColumn": "I" }
     ]
   },
   {
     "email": "user2@gmail.com",
     "emailPassword": "gmail-app-password-2",
     "accounts": [
-      { "broker": "finvasia", "accountId": "FA9999", "pdfPassword": "pdf-pwd-3" }
+      { "broker": "finvasia", "accountId": "FA9999", "pdfPassword": "pdf-pwd-3", "sheetStartColumn": "N" }
     ]
   }
 ]
 ```
 
-The flattened account order (mailbox-by-mailbox, account-by-account) defines the Google Sheet column order — keep it stable across runs.
+`sheetStartColumn` is the leftmost Google Sheet column for that account's daily values. Each account writes a contiguous 5-column block at that position:
+
+| Offset | Column (e.g. start = `D`) | Value |
+|---|---|---|
+| 0 | `D` | `payin_payout_obligation` |
+| 1 | `E` | `net_brokerage` |
+| 2 | `F` | `other_charges` |
+| 3 | `G` | `total_charges` (= `net_brokerage + other_charges`, computed by `updateSheet.js`) |
+| 4 | `H` | `final_net` |
+
+Columns A–C are reserved for serial number / day name / formatted date. Pick `sheetStartColumn` for each account so the per-account 5-column blocks don't overlap; gaps between blocks (and any cells with formulas) are preserved from the previous row via `PASTE_FORMULA`.
 
 ### Adding a New Broker
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This project consists of three main scripts:
 Before running the scripts, you need to set up a `.env` file with the following variables:
 
 ```env
-BROKER_ACCOUNTS_JSON=[{"email":"user1@gmail.com","emailPassword":"app-pwd-1","accounts":[{"broker":"finvasia","accountId":"FA1234","pdfPassword":"pdf-pwd-1"},{"broker":"angelone","accountId":"R59799620","pdfPassword":"pdf-pwd-2"}]}]
+BROKER_ACCOUNTS_JSON=[{"email":"user1@gmail.com","emailPassword":"app-pwd-1","accounts":[{"broker":"finvasia","accountId":"FA1234","pdfPassword":"pdf-pwd-1","sheetStartColumn":"D"},{"broker":"angelone","accountId":"R59799620","pdfPassword":"pdf-pwd-2","sheetStartColumn":"I"}]}]
 GOOGLE_CREDENTIALS=Base64_Encoded_Google_Credentials_JSON
 GOOGLE_SHEET_ID=your_google_sheet_id
 SHEET_GID=your_sheet_gid
@@ -35,21 +35,33 @@ SHEET_NAME=your_sheet_name
     "email": "user1@gmail.com",
     "emailPassword": "gmail-app-password-1",
     "accounts": [
-      { "broker": "finvasia", "accountId": "FA1234", "pdfPassword": "pdf-pwd-1" },
-      { "broker": "angelone",  "accountId": "R59799620", "pdfPassword": "pdf-pwd-2" }
+      { "broker": "finvasia", "accountId": "FA1234", "pdfPassword": "pdf-pwd-1", "sheetStartColumn": "D" },
+      { "broker": "angelone",  "accountId": "R59799620", "pdfPassword": "pdf-pwd-2", "sheetStartColumn": "I" }
     ]
   },
   {
     "email": "user2@gmail.com",
     "emailPassword": "gmail-app-password-2",
     "accounts": [
-      { "broker": "finvasia", "accountId": "FA9999", "pdfPassword": "pdf-pwd-3" }
+      { "broker": "finvasia", "accountId": "FA9999", "pdfPassword": "pdf-pwd-3", "sheetStartColumn": "N" }
     ]
   }
 ]
 ```
 
-Supported `broker` values: `finvasia`, `angelone`. The flattened account order (mailbox-by-mailbox, then account-by-account) determines the Google Sheet column order — keep it stable across runs.
+Supported `broker` values: `finvasia`, `angelone`.
+
+`sheetStartColumn` is the leftmost Google Sheet column for that account's daily values. Each account writes a contiguous 5-column block starting there:
+
+| Offset | Column (e.g. start = `D`) | Value                                                |
+| ------ | ------------------------- | ---------------------------------------------------- |
+| 0      | `D`                       | `payin_payout_obligation`                            |
+| 1      | `E`                       | `net_brokerage`                                      |
+| 2      | `F`                       | `other_charges`                                      |
+| 3      | `G`                       | `total_charges` (= `net_brokerage + other_charges`)  |
+| 4      | `H`                       | `final_net`                                          |
+
+Columns A–C are reserved for the serial number, day name and formatted date. Pick `sheetStartColumn` per account so the 5-column blocks don't overlap; any other columns (gaps between blocks, or formulas further right) are preserved from the previous row.
 
 ### Explanation:
 
@@ -85,7 +97,7 @@ Supported `broker` values: `finvasia`, `angelone`. The flattened account order (
 ## Example `.env` (Generic)
 
 ```env
-BROKER_ACCOUNTS_JSON=[{"email":"user1@gmail.com","emailPassword":"yourpassword1","accounts":[{"broker":"finvasia","accountId":"accountid1","pdfPassword":"pdfpwd1"}]},{"email":"user2@gmail.com","emailPassword":"yourpassword2","accounts":[{"broker":"angelone","accountId":"accountid2","pdfPassword":"pdfpwd2"}]}]
+BROKER_ACCOUNTS_JSON=[{"email":"user1@gmail.com","emailPassword":"yourpassword1","accounts":[{"broker":"finvasia","accountId":"accountid1","pdfPassword":"pdfpwd1","sheetStartColumn":"D"}]},{"email":"user2@gmail.com","emailPassword":"yourpassword2","accounts":[{"broker":"angelone","accountId":"accountid2","pdfPassword":"pdfpwd2","sheetStartColumn":"I"}]}]
 GOOGLE_CREDENTIALS=your_base64_encoded_service_account_json
 GOOGLE_SHEET_ID=your_google_sheet_id_here
 SHEET_GID=your_sheet_gid_here

--- a/README.md
+++ b/README.md
@@ -20,26 +20,46 @@ This project consists of three main scripts:
 Before running the scripts, you need to set up a `.env` file with the following variables:
 
 ```env
-EMAILS=email1@gmail.com,email2@gmail.com
-PASSWORDS=password1,password2
-ACCOUNT_IDS=accountid1,accountid2
+BROKER_ACCOUNTS_JSON=[{"email":"user1@gmail.com","emailPassword":"app-pwd-1","accounts":[{"broker":"finvasia","accountId":"FA1234","pdfPassword":"pdf-pwd-1"},{"broker":"angelone","accountId":"R59799620","pdfPassword":"pdf-pwd-2"}]}]
 GOOGLE_CREDENTIALS=Base64_Encoded_Google_Credentials_JSON
 GOOGLE_SHEET_ID=your_google_sheet_id
 SHEET_GID=your_sheet_gid
 SHEET_NAME=your_sheet_name
 ```
 
+`BROKER_ACCOUNTS_JSON` models the real 1-to-N relationship between a Gmail inbox and the broker accounts whose contract notes land in it. Pretty-printed:
+
+```json
+[
+  {
+    "email": "user1@gmail.com",
+    "emailPassword": "gmail-app-password-1",
+    "accounts": [
+      { "broker": "finvasia", "accountId": "FA1234", "pdfPassword": "pdf-pwd-1" },
+      { "broker": "angelone",  "accountId": "R59799620", "pdfPassword": "pdf-pwd-2" }
+    ]
+  },
+  {
+    "email": "user2@gmail.com",
+    "emailPassword": "gmail-app-password-2",
+    "accounts": [
+      { "broker": "finvasia", "accountId": "FA9999", "pdfPassword": "pdf-pwd-3" }
+    ]
+  }
+]
+```
+
+Supported `broker` values: `finvasia`, `angelone`. The flattened account order (mailbox-by-mailbox, then account-by-account) determines the Google Sheet column order — keep it stable across runs.
+
 ### Explanation:
 
-| Variable             | Description                                                                                 |
-| -------------------- | ------------------------------------------------------------------------------------------- |
-| `EMAILS`             | Comma-separated list of Gmail addresses to fetch mails from.                                |
-| `PASSWORDS`          | Corresponding comma-separated passwords for the above emails (use app passwords if needed). |
-| `ACCOUNT_IDS`        | Comma-separated account IDs to match with extracted trades.                                 |
-| `GOOGLE_CREDENTIALS` | Base64 encoded service account JSON credentials for Google Sheets API access.               |
-| `GOOGLE_SHEET_ID`    | ID of the target Google Sheet where data should be updated.                                 |
-| `SHEET_GID`          | GID of the specific sheet/tab inside the Google Sheet.                                      |
-| `SHEET_NAME`         | Name of the specific sheet/tab inside the Google Sheet.                                     |
+| Variable               | Description                                                                                                                                |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `BROKER_ACCOUNTS_JSON` | JSON array of mailboxes, each with `email`, `emailPassword`, and `accounts[]` (each account has `broker`, `accountId`, `pdfPassword`).     |
+| `GOOGLE_CREDENTIALS`   | Base64 encoded service account JSON credentials for Google Sheets API access.                                                              |
+| `GOOGLE_SHEET_ID`      | ID of the target Google Sheet where data should be updated.                                                                                |
+| `SHEET_GID`            | GID of the specific sheet/tab inside the Google Sheet.                                                                                     |
+| `SHEET_NAME`           | Name of the specific sheet/tab inside the Google Sheet.                                                                                    |
 
 ---
 
@@ -65,9 +85,7 @@ SHEET_NAME=your_sheet_name
 ## Example `.env` (Generic)
 
 ```env
-EMAILS=user1@gmail.com,user2@gmail.com
-PASSWORDS=yourpassword1,yourpassword2
-ACCOUNT_IDS=accountid1,accountid2
+BROKER_ACCOUNTS_JSON=[{"email":"user1@gmail.com","emailPassword":"yourpassword1","accounts":[{"broker":"finvasia","accountId":"accountid1","pdfPassword":"pdfpwd1"}]},{"email":"user2@gmail.com","emailPassword":"yourpassword2","accounts":[{"broker":"angelone","accountId":"accountid2","pdfPassword":"pdfpwd2"}]}]
 GOOGLE_CREDENTIALS=your_base64_encoded_service_account_json
 GOOGLE_SHEET_ID=your_google_sheet_id_here
 SHEET_GID=your_sheet_gid_here
@@ -87,15 +105,13 @@ To use this project with **GitHub Actions**, make sure you add the environment v
 3. Click **"New repository secret"**.
 4. Add each of the following as separate secrets:
 
-| GitHub Secret Name   | Corresponds to .env Variable |
-| -------------------- | ---------------------------- |
-| `EMAILS`             | `EMAILS`                     |
-| `PASSWORDS`          | `PASSWORDS`                  |
-| `ACCOUNT_IDS`        | `ACCOUNT_IDS`                |
-| `GOOGLE_CREDENTIALS` | `GOOGLE_CREDENTIALS`         |
-| `GOOGLE_SHEET_ID`    | `GOOGLE_SHEET_ID`            |
-| `SHEET_GID`          | `SHEET_GID`                  |
-| `SHEET_NAME`         | `SHEET_NAME`                 |
+| GitHub Secret Name     | Corresponds to .env Variable |
+| ---------------------- | ---------------------------- |
+| `BROKER_ACCOUNTS_JSON` | `BROKER_ACCOUNTS_JSON`       |
+| `GOOGLE_CREDENTIALS`   | `GOOGLE_CREDENTIALS`         |
+| `GOOGLE_SHEET_ID`      | `GOOGLE_SHEET_ID`            |
+| `SHEET_GID`            | `SHEET_GID`                  |
+| `SHEET_NAME`           | `SHEET_NAME`                 |
 
 ### Notes:
 
@@ -104,9 +120,7 @@ To use this project with **GitHub Actions**, make sure you add the environment v
 
 ```yaml
 env:
-  EMAILS: ${{ secrets.EMAILS }}
-  PASSWORDS: ${{ secrets.PASSWORDS }}
-  ACCOUNT_IDS: ${{ secrets.ACCOUNT_IDS }}
+  BROKER_ACCOUNTS_JSON: ${{ secrets.BROKER_ACCOUNTS_JSON }}
   GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
   GOOGLE_SHEET_ID: ${{ secrets.GOOGLE_SHEET_ID }}
   SHEET_GID: ${{ secrets.SHEET_GID }}

--- a/brokers/angelone.js
+++ b/brokers/angelone.js
@@ -1,0 +1,23 @@
+function subject(accountId, date) {
+  const dd = String(date.getDate()).padStart(2, "0");
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const yyyy = date.getFullYear();
+  return `Contract Note Cum Tax Invoice ${accountId} ${dd}/${mm}/${yyyy}`;
+}
+
+function extract(text) {
+  const totalMatch = text.match(/TOTAL\(NET\)((?:-?\d+\.\d{2}){11})/);
+  if (!totalMatch) return { error: "Angel One TOTAL(NET) line not matched" };
+  const nums = totalMatch[1].match(/-?\d+\.\d{2}/g).map(parseFloat);
+
+  const brokerageMatch = text.match(/Total Brokerage\s*=\s*(\d+\.\d{2})/);
+  if (!brokerageMatch) return { error: "Angel One Total Brokerage not matched" };
+
+  return {
+    payin_payout_obligation: nums[0],
+    final_net: nums[10],
+    net_brokerage: parseFloat(brokerageMatch[1]),
+  };
+}
+
+module.exports = { subject, extract };

--- a/brokers/angelone.js
+++ b/brokers/angelone.js
@@ -13,10 +13,15 @@ function extract(text) {
   const brokerageMatch = text.match(/Total Brokerage\s*=\s*(\d+\.\d{2})/);
   if (!brokerageMatch) return { error: "Angel One Total Brokerage not matched" };
 
+  const rawObligation = nums[0];
+  const finalNet = nums[10];
+  const brokerage = parseFloat(brokerageMatch[1]);
+
   return {
-    payin_payout_obligation: nums[0],
-    final_net: nums[10],
-    net_brokerage: parseFloat(brokerageMatch[1]),
+    payin_payout_obligation: rawObligation - brokerage,
+    final_net: finalNet,
+    net_brokerage: brokerage,
+    other_charges: finalNet - rawObligation,
   };
 }
 

--- a/brokers/finvasia.js
+++ b/brokers/finvasia.js
@@ -1,0 +1,20 @@
+function subject(accountId, date) {
+  const dd = String(date.getDate()).padStart(2, "0");
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const yyyy = date.getFullYear();
+  return `Combined Contract Note for ${accountId} ${dd}-${mm}-${yyyy}`;
+}
+
+function extract(text) {
+  const pattern =
+    /NSE\s*FNO(?:\s*-\s*\w+)?\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(-?\d+\.\d+)\s+(-?\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)/;
+  const match = text.match(pattern);
+  if (!match) return { error: "Finvasia NSE FNO line not matched" };
+  return {
+    payin_payout_obligation: parseFloat(match[8]),
+    final_net: parseFloat(match[7]),
+    net_brokerage: parseFloat(match[10]),
+  };
+}
+
+module.exports = { subject, extract };

--- a/brokers/index.js
+++ b/brokers/index.js
@@ -38,7 +38,12 @@ function loadBrokerAccounts() {
     for (const acc of mb.accounts) {
       if (!acc.broker || !acc.accountId || !acc.pdfPassword) {
         throw new Error(
-          `Each account needs { broker, accountId, pdfPassword }; got ${JSON.stringify(acc)}`
+          `Each account needs { broker, accountId, pdfPassword, sheetStartColumn }; got ${JSON.stringify(acc)}`
+        );
+      }
+      if (!acc.sheetStartColumn || !/^[A-Z]+$/.test(acc.sheetStartColumn)) {
+        throw new Error(
+          `Account ${acc.accountId} needs sheetStartColumn as an A-Z letter (e.g. "D"); got ${JSON.stringify(acc.sheetStartColumn)}`
         );
       }
       getBroker(acc.broker);
@@ -55,6 +60,7 @@ function flattenAccounts(config) {
         email: mb.email,
         broker: acc.broker,
         accountId: acc.accountId,
+        sheetStartColumn: acc.sheetStartColumn,
       });
     }
   }

--- a/brokers/index.js
+++ b/brokers/index.js
@@ -1,0 +1,94 @@
+const finvasia = require("./finvasia");
+const angelone = require("./angelone");
+
+const BROKERS = { finvasia, angelone };
+
+const SEP = "__";
+
+function getBroker(name) {
+  const b = BROKERS[name];
+  if (!b) {
+    throw new Error(
+      `Unknown broker "${name}". Supported: ${Object.keys(BROKERS).join(", ")}`
+    );
+  }
+  return b;
+}
+
+function loadBrokerAccounts() {
+  const raw = process.env.BROKER_ACCOUNTS_JSON;
+  if (!raw) throw new Error("BROKER_ACCOUNTS_JSON env var is required");
+
+  let config;
+  try {
+    config = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`BROKER_ACCOUNTS_JSON is not valid JSON: ${err.message}`);
+  }
+  if (!Array.isArray(config)) {
+    throw new Error("BROKER_ACCOUNTS_JSON must be a JSON array of mailboxes");
+  }
+
+  for (const mb of config) {
+    if (!mb.email || !mb.emailPassword || !Array.isArray(mb.accounts)) {
+      throw new Error(
+        `Each mailbox needs { email, emailPassword, accounts[] }; got ${JSON.stringify(mb)}`
+      );
+    }
+    for (const acc of mb.accounts) {
+      if (!acc.broker || !acc.accountId || !acc.pdfPassword) {
+        throw new Error(
+          `Each account needs { broker, accountId, pdfPassword }; got ${JSON.stringify(acc)}`
+        );
+      }
+      getBroker(acc.broker);
+    }
+  }
+  return config;
+}
+
+function flattenAccounts(config) {
+  const flat = [];
+  for (const mb of config) {
+    for (const acc of mb.accounts) {
+      flat.push({
+        email: mb.email,
+        broker: acc.broker,
+        accountId: acc.accountId,
+      });
+    }
+  }
+  return flat;
+}
+
+function safeEmail(email) {
+  return email.replace(/[@.]/g, "_");
+}
+
+function makeFileName(email, broker, accountId, originalName) {
+  return `${safeEmail(email)}${SEP}${broker}${SEP}${accountId}${SEP}${originalName}`;
+}
+
+function parseFileName(filename) {
+  let name = filename;
+  if (name.endsWith("_decrypted.pdf")) {
+    name = name.slice(0, -"_decrypted.pdf".length) + ".pdf";
+  }
+  const parts = name.split(SEP);
+  if (parts.length < 4) return null;
+  return {
+    email: parts[0],
+    broker: parts[1],
+    accountId: parts[2],
+    originalName: parts.slice(3).join(SEP),
+  };
+}
+
+module.exports = {
+  BROKERS,
+  getBroker,
+  loadBrokerAccounts,
+  flattenAccounts,
+  makeFileName,
+  parseFileName,
+};

--- a/fetchMail.js
+++ b/fetchMail.js
@@ -5,49 +5,28 @@ const fs = require("fs");
 const path = require("path");
 const { execSync } = require("child_process");
 
-// ⏲️ Target date (defaults to yesterday)
+const {
+  loadBrokerAccounts,
+  getBroker,
+  makeFileName,
+} = require("./brokers");
+
 const targetDate = process.env.TARGET_DATE
   ? new Date(process.env.TARGET_DATE)
   : new Date(Date.now() - 24 * 60 * 60 * 1000);
 const formattedDate = targetDate.toISOString().slice(0, 10);
 
-// 📁 Ensure 'data' folder exists
 const dataDir = path.join(__dirname, "data");
 if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir);
 
-// 📦 Parse from .env
-const emails = process.env.EMAILS.split(",");
-const passwords = process.env.PASSWORDS.split(",");
-const accountIds = process.env.ACCOUNT_IDS.split(",");
-const pdfPasswords = process.env.PDF_PASSWORDS.split(",");
-
-// 🧪 Sanity check
-if (
-  emails.length !== passwords.length ||
-  emails.length !== accountIds.length ||
-  emails.length !== pdfPasswords.length
-) {
-  throw new Error(
-    "EMAILS, PASSWORDS, ACCOUNT_IDS, and PDF_PASSWORDS must be of the same length in .env"
-  );
-}
-
-const accounts = emails.map((email, i) => ({
-  email,
-  password: passwords[i],
-  accountId: accountIds[i],
-  pdfPassword: pdfPasswords[i],
-}));
+const mailboxes = loadBrokerAccounts();
 
 async function decryptWithQpdf(filePath, password) {
   const decryptedPath = filePath.replace(/\.pdf$/i, "_decrypted.pdf");
-
   try {
     execSync(
       `qpdf --password='${password}' --decrypt "${filePath}" "${decryptedPath}"`,
-      {
-        stdio: "ignore",
-      }
+      { stdio: "ignore" }
     );
     console.log("🔓 PDF decrypted using qpdf:", decryptedPath);
     return decryptedPath;
@@ -57,90 +36,112 @@ async function decryptWithQpdf(filePath, password) {
   }
 }
 
-async function processAccount(account) {
+function fetchAttachmentsForSubject(imap, subjectSearch) {
+  return new Promise((resolve, reject) => {
+    imap.search(
+      [["SINCE", formattedDate], ["SUBJECT", subjectSearch]],
+      (err, results) => {
+        if (err) return reject(err);
+        if (!results || !results.length) return resolve([]);
+
+        const attachments = [];
+        const parsePromises = [];
+        const f = imap.fetch(results, { bodies: "", struct: true });
+
+        f.on("message", (msg) => {
+          msg.on("body", (stream) => {
+            parsePromises.push(
+              simpleParser(stream).then((parsed) => {
+                for (const att of parsed.attachments || []) {
+                  if (
+                    att.filename &&
+                    att.filename.toLowerCase().endsWith(".pdf")
+                  ) {
+                    attachments.push(att);
+                  }
+                }
+              })
+            );
+          });
+        });
+
+        f.once("error", reject);
+        f.once("end", async () => {
+          try {
+            await Promise.all(parsePromises);
+            resolve(attachments);
+          } catch (err) {
+            reject(err);
+          }
+        });
+      }
+    );
+  });
+}
+
+async function processMailbox(mailbox) {
   return new Promise((resolve, reject) => {
     const imap = new Imap({
-      user: account.email,
-      password: account.password,
+      user: mailbox.email,
+      password: mailbox.emailPassword,
       host: "imap.gmail.com",
       port: 993,
       tls: true,
       tlsOptions: { rejectUnauthorized: false },
     });
 
-    function openInbox(cb) {
-      imap.openBox("INBOX", false, cb);
-    }
-
     imap.once("ready", () => {
-      openInbox((err, box) => {
-        if (err) return reject(err);
+      imap.openBox("INBOX", false, async (err) => {
+        if (err) {
+          imap.end();
+          return reject(err);
+        }
 
-        const formattedDateForSubject = targetDate
-          .toLocaleDateString("en-GB")
-          .split("/")
-          .join("-");
+        try {
+          for (const acc of mailbox.accounts) {
+            const broker = getBroker(acc.broker);
+            const subjectSearch = broker.subject(acc.accountId, targetDate);
+            console.log(
+              `🔎 ${mailbox.email} → ${acc.broker}/${acc.accountId}: "${subjectSearch}"`
+            );
 
-        const subjectSearch = `Combined Contract Note for ${account.accountId} ${formattedDateForSubject}`;
-
-        imap.search(
-          [
-            ["SINCE", formattedDate],
-            ["SUBJECT", subjectSearch],
-          ],
-          (err, results) => {
-            if (err) return reject(err);
-            if (!results.length) {
+            const attachments = await fetchAttachmentsForSubject(
+              imap,
+              subjectSearch
+            );
+            if (!attachments.length) {
               console.log(
-                `📭 No emails found for ${account.email} with account ID ${account.accountId}`
+                `📭 No mail for ${acc.broker}/${acc.accountId} in ${mailbox.email}`
               );
-              imap.end();
-              return resolve();
+              continue;
             }
 
-            const f = imap.fetch(results, { bodies: "", struct: true });
-
-            f.on("message", (msg) => {
-              msg.on("body", (stream) => {
-                simpleParser(stream, async (err, parsed) => {
-                  const attachments = parsed.attachments || [];
-                  for (const attachment of attachments) {
-                    if (attachment.filename.toLowerCase().endsWith(".pdf")) {
-                      const filename = `${account.email.replace(
-                        /[@.]/g,
-                        "_"
-                      )}_${attachment.filename}`;
-                      const filePath = path.join(dataDir, filename);
-                      fs.writeFileSync(filePath, attachment.content);
-                      console.log(`📎 Saved attachment: ${filename}`);
-
-                      const decryptedPath = await decryptWithQpdf(
-                        filePath,
-                        account.pdfPassword
-                      );
-                      if (!decryptedPath) {
-                        console.warn(
-                          `⚠️ Could not decrypt PDF for ${account.email}`
-                        );
-                      }
-                    }
-                  }
-                });
-              });
-            });
-
-            f.once("end", () => {
-              console.log(`✅ Finished processing ${account.email}`);
-              imap.end();
-              resolve();
-            });
+            for (const att of attachments) {
+              const filename = makeFileName(
+                mailbox.email,
+                acc.broker,
+                acc.accountId,
+                att.filename
+              );
+              const filePath = path.join(dataDir, filename);
+              fs.writeFileSync(filePath, att.content);
+              console.log(`📎 Saved attachment: ${filename}`);
+              await decryptWithQpdf(filePath, acc.pdfPassword);
+            }
           }
-        );
+
+          console.log(`✅ Finished processing ${mailbox.email}`);
+          imap.end();
+          resolve();
+        } catch (err) {
+          imap.end();
+          reject(err);
+        }
       });
     });
 
     imap.once("error", (err) => {
-      console.error(`❌ IMAP error for ${account.email}: ${err.message}`);
+      console.error(`❌ IMAP error for ${mailbox.email}: ${err.message}`);
       reject(err);
     });
 
@@ -149,11 +150,11 @@ async function processAccount(account) {
 }
 
 (async () => {
-  for (const acc of accounts) {
+  for (const mb of mailboxes) {
     try {
-      await processAccount(acc);
+      await processMailbox(mb);
     } catch (err) {
-      console.error(`⚠️ Failed for ${acc.email}: ${err.message}`);
+      console.error(`⚠️ Failed for ${mb.email}: ${err.message}`);
     }
   }
 })();

--- a/parser.js
+++ b/parser.js
@@ -3,6 +3,13 @@ const path = require("path");
 const pdfParse = require("pdf-parse");
 const { getBroker, parseFileName } = require("./brokers");
 
+const SUMMARY_FIELDS = [
+  "payin_payout_obligation",
+  "final_net",
+  "net_brokerage",
+  "other_charges",
+];
+
 const dataDir = path.join(__dirname, "data");
 const pdfFiles = fs
   .readdirSync(dataDir)
@@ -15,11 +22,7 @@ if (!pdfFiles.length) {
 
 const mergedSummary = {
   individual_account: [],
-  total: {
-    payin_payout_obligation: 0,
-    final_net: 0,
-    net_brokerage: 0,
-  },
+  total: Object.fromEntries(SUMMARY_FIELDS.map((f) => [f, 0])),
 };
 
 (async () => {
@@ -49,19 +52,17 @@ const mergedSummary = {
       }
       console.log(`🎯 ${meta.broker} summary for ${meta.accountId}:`, summary);
 
-      mergedSummary.individual_account.push({
+      const accountEntry = {
         account: meta.accountId,
         broker: meta.broker,
         email: meta.email,
-        payin_payout_obligation: summary.payin_payout_obligation,
-        final_net: summary.final_net,
-        net_brokerage: summary.net_brokerage,
-      });
-
-      mergedSummary.total.payin_payout_obligation +=
-        summary.payin_payout_obligation;
-      mergedSummary.total.final_net += summary.final_net;
-      mergedSummary.total.net_brokerage += summary.net_brokerage;
+      };
+      for (const f of SUMMARY_FIELDS) {
+        const v = summary[f] ?? 0;
+        accountEntry[f] = v;
+        mergedSummary.total[f] += v;
+      }
+      mergedSummary.individual_account.push(accountEntry);
     } catch (err) {
       console.error(`❌ Error parsing ${file}:`, err.message);
     }

--- a/parser.js
+++ b/parser.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const pdfParse = require("pdf-parse");
+const { getBroker, parseFileName } = require("./brokers");
 
 const dataDir = path.join(__dirname, "data");
 const pdfFiles = fs
@@ -23,61 +24,50 @@ const mergedSummary = {
 
 (async () => {
   for (const file of pdfFiles) {
+    const meta = parseFileName(file);
+    if (!meta) {
+      console.warn(
+        `⚠️ Skipping ${file}: filename does not embed <email>__<broker>__<accountId>__... — re-fetch on the new pipeline.`
+      );
+      continue;
+    }
+
     const pdfPath = path.join(dataDir, file);
     const pdfBuffer = fs.readFileSync(pdfPath);
 
     try {
       const data = await pdfParse(pdfBuffer);
-      const text = data.text;
-      console.log(`✅ Loaded PDF: ${file}`);
+      console.log(
+        `✅ Loaded PDF: ${file} (broker=${meta.broker}, account=${meta.accountId})`
+      );
 
-      const nseFno = extractNSEFNO(text);
-      console.log("🎯 NSE FNO Summary:", nseFno);
+      const broker = getBroker(meta.broker);
+      const summary = broker.extract(data.text);
+      if (summary.error) {
+        console.error(`❌ Extractor failed for ${file}: ${summary.error}`);
+        continue;
+      }
+      console.log(`🎯 ${meta.broker} summary for ${meta.accountId}:`, summary);
 
-      // Assuming the file name format is {account}_CombinedContractNote.pdf
-      const accountName = path.basename(file, ".pdf");
+      mergedSummary.individual_account.push({
+        account: meta.accountId,
+        broker: meta.broker,
+        email: meta.email,
+        payin_payout_obligation: summary.payin_payout_obligation,
+        final_net: summary.final_net,
+        net_brokerage: summary.net_brokerage,
+      });
 
-      // Create the account entry
-      const accountEntry = {
-        account: accountName,
-        payin_payout_obligation: nseFno.payin_payout_obligation,
-        final_net: nseFno.final_net,
-        net_brokerage: nseFno.net_brokerage,
-      };
-
-      // Add this account entry to the individual_account array
-      mergedSummary.individual_account.push(accountEntry);
-
-      // Update the total sums
       mergedSummary.total.payin_payout_obligation +=
-        nseFno.payin_payout_obligation;
-      mergedSummary.total.final_net += nseFno.final_net;
-      mergedSummary.total.net_brokerage += nseFno.net_brokerage;
+        summary.payin_payout_obligation;
+      mergedSummary.total.final_net += summary.final_net;
+      mergedSummary.total.net_brokerage += summary.net_brokerage;
     } catch (err) {
       console.error(`❌ Error parsing ${file}:`, err.message);
     }
   }
 
-  // Save the merged summary to a JSON file
   const outputPath = path.join(__dirname, "daily_summary.json");
   fs.writeFileSync(outputPath, JSON.stringify(mergedSummary, null, 2));
   console.log(`📦 Merged summary saved to daily_summary.json\n`);
 })();
-
-// 🔍 Extractor logic
-function extractNSEFNO(text) {
-  const pattern =
-    /NSE\s*FNO(?:\s*-\s*\w+)?\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(-?\d+\.\d+)\s+(-?\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)/;
-
-  const match = text.match(pattern);
-
-  if (!match) {
-    return { error: "NSE FNO line not matched" };
-  }
-
-  return {
-    payin_payout_obligation: parseFloat(match[8]),
-    final_net: parseFloat(match[7]),
-    net_brokerage: parseFloat(match[10]),
-  };
-}

--- a/updateSheet.js
+++ b/updateSheet.js
@@ -16,8 +16,26 @@ function columnToLetter(column) {
   return letter;
 }
 
+function letterToColumn(letter) {
+  let col = 0;
+  for (let i = 0; i < letter.length; i++) {
+    col = col * 26 + (letter.charCodeAt(i) - 64);
+  }
+  return col;
+}
+
+const ACCOUNT_COLUMN_COUNT = 5;
+
+function buildAccountValues(match) {
+  const payin = match?.payin_payout_obligation ?? 0;
+  const brokerage = match?.net_brokerage ?? 0;
+  const other = match?.other_charges ?? 0;
+  const totalCharges = brokerage + other;
+  const finalNet = match?.final_net ?? 0;
+  return [payin, brokerage, other, totalCharges, finalNet];
+}
+
 async function updateGoogleSheet() {
-  // Decode credentials
   const credentials = JSON.parse(
     Buffer.from(process.env.GOOGLE_CREDENTIALS, "base64").toString("utf8")
   );
@@ -35,7 +53,6 @@ async function updateGoogleSheet() {
     const sheetId = process.env.SHEET_GID;
     const sheetName = process.env.SHEET_NAME;
 
-    // --- Step 1: Get the last row from row_tracker.json (if it exists)
     let lastRow = 0;
     try {
       const trackerRaw = fs.readFileSync("row_tracker.json", "utf-8");
@@ -48,19 +65,16 @@ async function updateGoogleSheet() {
       );
     }
 
-    // --- Step 2: If no row found in row_tracker.json, get the last row from the sheet
     if (lastRow === 0) {
       const readResponse = await sheets.spreadsheets.values.get({
         spreadsheetId,
-        range: `${sheetName}!A:A`, // Read data from column A to check the last filled row
+        range: `${sheetName}!A:A`,
       });
-
       const rows = readResponse.data.values;
-      lastRow = rows ? rows.length : 0; // Calculate the last row based on column A
+      lastRow = rows ? rows.length : 0;
       console.log("Using last row from Google Sheet:", lastRow);
     }
 
-    // --- Step 3: Determine target date and check for duplicates
     const targetDate = process.env.TARGET_DATE
       ? new Date(process.env.TARGET_DATE)
       : (() => {
@@ -83,7 +97,7 @@ async function updateGoogleSheet() {
               spreadsheetId,
               range: `${sheetName}!A${lastRow}:ZZ${lastRow}`,
             })
-          ).data.values[0]
+          ).data.values?.[0] || []
         : [];
 
     const lastRowValue = lastRowData[0] || 0;
@@ -93,7 +107,7 @@ async function updateGoogleSheet() {
       console.log(`Date ${dateFormatted} already exists. Skipping update.`);
       return;
     }
-    // --- Step 4: Read daily_summary.json and prepare account values
+
     const summaryPath = "daily_summary.json";
     if (!fs.existsSync(summaryPath)) {
       console.log("No daily summary found. Skipping update.");
@@ -110,22 +124,8 @@ async function updateGoogleSheet() {
 
     const newRow = lastRow ? parseInt(lastRow) + 1 : 1;
     const newRowValue = lastRowValue ? parseInt(lastRowValue) + 1 : 1;
-    const rowValues = [newRowValue, dayName, dateFormatted];
 
-    flatAccounts.forEach((acc) => {
-      const match = data.individual_account.find(
-        (a) => a.account === acc.accountId
-      );
-      rowValues.push(match?.payin_payout_obligation || 0);
-      rowValues.push(
-        (match?.payin_payout_obligation - match?.final_net) || 0
-      );
-    });
-
-    const dataColumnCount = rowValues.length;
-
-    // Insert a new row before writing values
-    const insertRequest = {
+    await sheets.spreadsheets.batchUpdate({
       spreadsheetId,
       resource: {
         requests: [
@@ -142,23 +142,10 @@ async function updateGoogleSheet() {
           },
         ],
       },
-    };
-
-    await sheets.spreadsheets.batchUpdate(insertRequest);
-
-    // Insert values covering only the data columns
-    await sheets.spreadsheets.values.update({
-      spreadsheetId,
-      range: `${sheetName}!A${newRow}:${columnToLetter(dataColumnCount)}${newRow}`,
-      valueInputOption: "RAW",
-      resource: { values: [rowValues] },
     });
 
-    // --- Step 6: Copy formulas from the previous row (if any)
-    const formulaColsCount = Math.max(lastRowData.length - dataColumnCount, 0);
-
-    if (formulaColsCount > 0) {
-      const copyRequest = {
+    if (lastRow > 0 && lastRowData.length > 0) {
+      await sheets.spreadsheets.batchUpdate({
         spreadsheetId,
         resource: {
           requests: [
@@ -168,29 +155,52 @@ async function updateGoogleSheet() {
                   sheetId,
                   startRowIndex: lastRow - 1,
                   endRowIndex: lastRow,
-                  startColumnIndex: dataColumnCount,
-                  endColumnIndex: dataColumnCount + formulaColsCount,
+                  startColumnIndex: 0,
+                  endColumnIndex: lastRowData.length,
                 },
                 destination: {
                   sheetId,
                   startRowIndex: newRow - 1,
                   endRowIndex: newRow,
-                  startColumnIndex: dataColumnCount,
-                  endColumnIndex: dataColumnCount + formulaColsCount,
+                  startColumnIndex: 0,
+                  endColumnIndex: lastRowData.length,
                 },
                 pasteType: "PASTE_FORMULA",
               },
             },
           ],
         },
-      };
-
-      await sheets.spreadsheets.batchUpdate(copyRequest);
+      });
     }
+
+    const valueUpdates = [
+      {
+        range: `${sheetName}!A${newRow}:C${newRow}`,
+        values: [[newRowValue, dayName, dateFormatted]],
+      },
+    ];
+
+    for (const acc of flatAccounts) {
+      const match = data.individual_account.find(
+        (a) => a.account === acc.accountId
+      );
+      const startColNum = letterToColumn(acc.sheetStartColumn);
+      const endColLetter = columnToLetter(
+        startColNum + ACCOUNT_COLUMN_COUNT - 1
+      );
+      valueUpdates.push({
+        range: `${sheetName}!${acc.sheetStartColumn}${newRow}:${endColLetter}${newRow}`,
+        values: [buildAccountValues(match)],
+      });
+    }
+
+    await sheets.spreadsheets.values.batchUpdate({
+      spreadsheetId,
+      resource: { valueInputOption: "RAW", data: valueUpdates },
+    });
 
     console.log("✅ Sheet updated successfully!");
 
-    // --- Step 7: Save new lastUpdatedRow to row_tracker.json
     fs.writeFileSync(
       "row_tracker.json",
       JSON.stringify({ lastUpdatedRow: newRow }, null, 2),

--- a/updateSheet.js
+++ b/updateSheet.js
@@ -2,6 +2,7 @@ const { google } = require("googleapis");
 const { JWT } = require("google-auth-library");
 const dotenv = require("dotenv");
 const fs = require("fs");
+const { loadBrokerAccounts, flattenAccounts } = require("./brokers");
 
 dotenv.config();
 
@@ -105,20 +106,20 @@ async function updateGoogleSheet() {
       return;
     }
 
-    const accountIds = process.env.ACCOUNT_IDS
-      ? process.env.ACCOUNT_IDS.split(",")
-      : [];
+    const flatAccounts = flattenAccounts(loadBrokerAccounts());
 
     const newRow = lastRow ? parseInt(lastRow) + 1 : 1;
     const newRowValue = lastRowValue ? parseInt(lastRowValue) + 1 : 1;
     const rowValues = [newRowValue, dayName, dateFormatted];
 
-    accountIds.forEach((id) => {
-      const acct = data.individual_account.find(
-        (a) => a.account === id || a.account.includes(id)
+    flatAccounts.forEach((acc) => {
+      const match = data.individual_account.find(
+        (a) => a.account === acc.accountId
       );
-      rowValues.push(acct?.payin_payout_obligation || 0);
-      rowValues.push(acct?.payin_payout_obligation - acct?.final_net || 0);
+      rowValues.push(match?.payin_payout_obligation || 0);
+      rowValues.push(
+        (match?.payin_payout_obligation - match?.final_net) || 0
+      );
     });
 
     const dataColumnCount = rowValues.length;


### PR DESCRIPTION
## Summary
This PR introduces a pluggable broker architecture to support multiple contract-note formats (Finvasia and Angel One) and refactors the configuration model from flat comma-separated env vars to a hierarchical `BROKER_ACCOUNTS_JSON` that properly models the 1-to-N relationship between Gmail inboxes and broker accounts.

## Key Changes

- **New broker plugin system** (`brokers/index.js`, `brokers/finvasia.js`, `brokers/angelone.js`):
  - Each broker exports `subject(accountId, date)` to generate IMAP search strings and `extract(text)` to parse PDF text
  - Registry pattern allows easy addition of new brokers
  - Finvasia and Angel One extractors ported from hardcoded logic

- **Configuration refactor**:
  - Replaced `EMAILS`, `PASSWORDS`, `ACCOUNT_IDS`, `PDF_PASSWORDS` env vars with single `BROKER_ACCOUNTS_JSON`
  - New structure: array of mailboxes, each with email/password and an array of broker accounts
  - Each account specifies broker, accountId, pdfPassword, and `sheetStartColumn` (for Google Sheet layout)
  - Validation ensures all required fields and broker names are present

- **fetchMail.js refactoring**:
  - Now loads mailboxes from `BROKER_ACCOUNTS_JSON` instead of parsing flat env vars
  - Opens one IMAP connection per email, iterates accounts within that mailbox
  - Dispatches to broker-specific subject search via `getBroker()`
  - Filenames now embed broker and accountId: `<email>__<broker>__<accountId>__<originalName>.pdf`
  - Extracted `fetchAttachmentsForSubject()` helper for cleaner async handling

- **parser.js refactoring**:
  - Parses broker/accountId from filename using `parseFileName()`
  - Dispatches to broker-specific extractor via `getBroker()`
  - Simplified to handle any broker's field set dynamically
  - Removed hardcoded NSE FNO regex

- **updateSheet.js refactoring**:
  - Uses `flattenAccounts()` to resolve account-to-column mappings from config
  - Introduced `letterToColumn()` helper and `ACCOUNT_COLUMN_COUNT` constant
  - Each account writes a 5-column block (payin, brokerage, other, total, final_net) at its `sheetStartColumn`
  - Simplified row insertion and formula copying logic
  - Uses `batchUpdate()` for values instead of manual column counting

- **Documentation updates**:
  - README now explains `BROKER_ACCOUNTS_JSON` structure with examples
  - Clarified 5-column layout per account and column reservation
  - Updated architecture section to describe broker plugins and config loading

- **GitHub Actions workflow**:
  - Updated to use `BROKER_ACCOUNTS_JSON` secret instead of four separate secrets

## Notable Implementation Details

- Filename format `<email>__<broker>__<accountId>__<name>` allows parser to reconstruct metadata without config lookup
- `sheetStartColumn` is validated as A-Z letters; `letterToColumn()` converts to numeric indices for range calculations
- Broker extractors return a consistent field set; missing fields default to 0
- All formula columns from previous row are preserved via `PASTE_FORMULA` before selective value overwrites
- Error handling improved: broker validation at config load time, per-file skipping in parser if filename doesn't match new format

https://claude.ai/code/session_01DgX8MM6uxBBR4bSwWe79Rz