### PR TITLE
Fix Finvasia NSE FNO obligation and brokerage calculation

### DIFF
--- a/brokers/finvasia.js
+++ b/brokers/finvasia.js
@@ -10,10 +10,16 @@ function extract(text) {
     /NSE\s*FNO(?:\s*-\s*\w+)?\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(-?\d+\.\d+)\s+(-?\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)/;
   const match = text.match(pattern);
   if (!match) return { error: "Finvasia NSE FNO line not matched" };
+
+  const rawObligation = parseFloat(match[8]);
+  const finalNet = parseFloat(match[7]);
+  const brokerage = parseFloat(match[10]);
+
   return {
-    payin_payout_obligation: parseFloat(match[8]),
-    final_net: parseFloat(match[7]),
-    net_brokerage: parseFloat(match[10]),
+    payin_payout_obligation: rawObligation - brokerage,
+    final_net: finalNet,
+    net_brokerage: brokerage,
+    other_charges: finalNet - rawObligation,
   };
 }
 


### PR DESCRIPTION
## Summary
Corrected the calculation logic for Finvasia NSE FNO statement parsing to properly separate brokerage charges from the raw obligation amount and added tracking of other charges.

## Key Changes
- Extracted raw values into intermediate variables for clarity and reusability
- Modified `payin_payout_obligation` calculation to subtract brokerage from the raw obligation value
- Added new `other_charges` field to capture the difference between final net and raw obligation
- Maintained `final_net` and `net_brokerage` as direct parsed values

## Implementation Details
The change reflects a more accurate interpretation of the Finvasia statement format where:
- Match[8] contains the raw obligation (before brokerage deduction)
- Match[10] contains the brokerage amount
- The actual payin/payout obligation should be the raw obligation minus brokerage
- Other charges are calculated as the difference between final net and raw obligation, providing visibility into additional fees beyond brokerage

https://claude.ai/code/session_01DgX8MM6uxBBR4bSwWe79Rz