### PR TITLE
Add body filter support for email attachment fetching

### DIFF
--- a/brokers/angelone.js
+++ b/brokers/angelone.js
@@ -1,8 +1,12 @@
-function subject(accountId, date) {
+function subject() {
+  return "Contract Note - Equity Segment";
+}
+
+function bodyFilter(date) {
   const dd = String(date.getDate()).padStart(2, "0");
   const mm = String(date.getMonth() + 1).padStart(2, "0");
   const yyyy = date.getFullYear();
-  return `Contract Note Cum Tax Invoice ${accountId} ${dd}/${mm}/${yyyy}`;
+  return `${dd}/${mm}/${yyyy}`;
 }
 
 function extract(text) {
@@ -25,4 +29,4 @@ function extract(text) {
   };
 }
 
-module.exports = { subject, extract };
+module.exports = { subject, bodyFilter, extract };

--- a/fetchMail.js
+++ b/fetchMail.js
@@ -36,7 +36,7 @@ async function decryptWithQpdf(filePath, password) {
   }
 }
 
-function fetchAttachmentsForSubject(imap, subjectSearch) {
+function fetchAttachmentsForSubject(imap, subjectSearch, bodyFilterStr) {
   return new Promise((resolve, reject) => {
     imap.search(
       [["SINCE", formattedDate], ["SUBJECT", subjectSearch]],
@@ -52,6 +52,10 @@ function fetchAttachmentsForSubject(imap, subjectSearch) {
           msg.on("body", (stream) => {
             parsePromises.push(
               simpleParser(stream).then((parsed) => {
+                if (bodyFilterStr) {
+                  const bodyText = parsed.text || parsed.html || "";
+                  if (!bodyText.includes(bodyFilterStr)) return;
+                }
                 for (const att of parsed.attachments || []) {
                   if (
                     att.filename &&
@@ -101,13 +105,17 @@ async function processMailbox(mailbox) {
           for (const acc of mailbox.accounts) {
             const broker = getBroker(acc.broker);
             const subjectSearch = broker.subject(acc.accountId, targetDate);
+            const bodyFilterStr = broker.bodyFilter
+              ? broker.bodyFilter(targetDate)
+              : null;
             console.log(
-              `🔎 ${mailbox.email} → ${acc.broker}/${acc.accountId}: "${subjectSearch}"`
+              `🔎 ${mailbox.email} → ${acc.broker}/${acc.accountId}: "${subjectSearch}"${bodyFilterStr ? ` (body filter: "${bodyFilterStr}")` : ""}`
             );
 
             const attachments = await fetchAttachmentsForSubject(
               imap,
-              subjectSearch
+              subjectSearch,
+              bodyFilterStr
             );
             if (!attachments.length) {
               console.log(


### PR DESCRIPTION
## Summary
This PR introduces a body filter mechanism to the email attachment fetching logic, allowing brokers to filter emails based on their message body content in addition to subject line matching. This enables more precise email filtering when multiple emails with the same subject may be received.

## Key Changes
- **fetchMail.js**: 
  - Added `bodyFilterStr` parameter to `fetchAttachmentsForSubject()` function
  - Implemented body content filtering logic that checks if parsed email body contains the filter string before processing attachments
  - Updated `processMailbox()` to retrieve and pass the body filter string from broker configuration
  - Enhanced console logging to display active body filters

- **brokers/angelone.js**:
  - Refactored `subject()` function to return a static subject line ("Contract Note - Equity Segment") instead of including account ID and date
  - Introduced new `bodyFilter()` function that returns a date-based filter string (DD/MM/YYYY format)
  - Updated module exports to include the new `bodyFilter` function

## Implementation Details
- The body filter is optional - brokers can omit it by not implementing the `bodyFilter` function
- Filtering checks both `parsed.text` and `parsed.html` fields to handle different email formats
- If a body filter is specified but the email body doesn't contain the filter string, the email is skipped entirely (no attachments are processed)
- This change maintains backward compatibility with brokers that don't implement body filtering

https://claude.ai/code/session_01KEh8eQkUQr4LFAKyWHWYrJ