### PR TITLE
Fix other_charges calculation to use absolute values

### DIFF
--- a/brokers/angelone.js
+++ b/brokers/angelone.js
@@ -25,7 +25,7 @@ function extract(text) {
     payin_payout_obligation: rawObligation - brokerage,
     final_net: finalNet,
     net_brokerage: brokerage,
-    other_charges: finalNet - rawObligation,
+    other_charges: Math.abs(finalNet - rawObligation),
   };
 }
 

--- a/brokers/finvasia.js
+++ b/brokers/finvasia.js
@@ -19,7 +19,7 @@ function extract(text) {
     payin_payout_obligation: rawObligation - brokerage,
     final_net: finalNet,
     net_brokerage: brokerage,
-    other_charges: finalNet - rawObligation,
+    other_charges: Math.abs(finalNet - rawObligation),
   };
 }
 


### PR DESCRIPTION
## Summary
Updated the `other_charges` calculation in both AngelOne and Finvasia brokers to use absolute values, ensuring the result is always non-negative regardless of the relationship between `finalNet` and `rawObligation`.

## Key Changes
- **brokers/angelone.js**: Wrapped `other_charges` calculation with `Math.abs()` to handle cases where `finalNet - rawObligation` could be negative
- **brokers/finvasia.js**: Applied the same fix to maintain consistency across broker implementations

## Implementation Details
The change ensures that `other_charges` always returns a positive value, which is more semantically correct for representing charges. This prevents potential issues with negative charge values that could occur when the final net amount is less than the raw obligation.

https://claude.ai/code/session_014R3NWF7vSAUryMFHLMvAuK