### PR TITLE
Remove final_net field from account data extraction

### DIFF
--- a/brokers/angelone.js
+++ b/brokers/angelone.js
@@ -23,7 +23,6 @@ function extract(text) {
 
   return {
     payin_payout_obligation: rawObligation - brokerage,
-    final_net: finalNet,
     net_brokerage: brokerage,
     other_charges: Math.abs(finalNet - rawObligation),
   };

--- a/brokers/finvasia.js
+++ b/brokers/finvasia.js
@@ -17,7 +17,6 @@ function extract(text) {
 
   return {
     payin_payout_obligation: rawObligation - brokerage,
-    final_net: finalNet,
     net_brokerage: brokerage,
     other_charges: Math.abs(finalNet - rawObligation),
   };

--- a/parser.js
+++ b/parser.js
@@ -5,7 +5,6 @@ const { getBroker, parseFileName } = require("./brokers");
 
 const SUMMARY_FIELDS = [
   "payin_payout_obligation",
-  "final_net",
   "net_brokerage",
   "other_charges",
 ];

--- a/updateSheet.js
+++ b/updateSheet.js
@@ -24,15 +24,14 @@ function letterToColumn(letter) {
   return col;
 }
 
-const ACCOUNT_COLUMN_COUNT = 5;
+const ACCOUNT_COLUMN_COUNT = 4;
 
 function buildAccountValues(match) {
   const payin = match?.payin_payout_obligation ?? 0;
   const brokerage = match?.net_brokerage ?? 0;
   const other = match?.other_charges ?? 0;
   const totalCharges = brokerage + other;
-  const finalNet = match?.final_net ?? 0;
-  return [payin, brokerage, other, totalCharges, finalNet];
+  return [payin, brokerage, other, totalCharges];
 }
 
 async function updateGoogleSheet() {


### PR DESCRIPTION
## Summary
This PR removes the `final_net` field from the account data extraction and processing pipeline. The field is no longer included in the data returned by broker parsers or stored in the Google Sheet.

## Key Changes
- Reduced `ACCOUNT_COLUMN_COUNT` from 5 to 4 in updateSheet.js
- Removed `final_net` from the `buildAccountValues()` function, which now returns only 4 values: payin, brokerage, other charges, and total charges
- Removed `final_net` field extraction from both angelone.js and finvasia.js broker parsers
- Removed `final_net` from the `SUMMARY_FIELDS` array in parser.js

## Implementation Details
The `final_net` value was previously calculated in the broker extraction functions but is no longer needed for the account summary. The other_charges field already captures the difference between final net and raw obligation, making the final_net field redundant in the output data structure.

https://claude.ai/code/session_01HMdANLCbitWZNk2oFQQKLc