### PR TITLE
Fix final_net column write and sheet date parsing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Gmail (IMAP) → fetchMail.js → data/*.pdf (encrypted)
                         updateSheet.js → Google Sheet row
 ```
 
-**`brokers/`** — Per-broker plugins. Each plugin exports `subject(accountId, date)` (the IMAP `SUBJECT` search string for that broker's contract-note emails) and `extract(text)` (returns `{ payin_payout_obligation, final_net, net_brokerage }` from decrypted PDF text). `brokers/index.js` is the registry plus the `BROKER_ACCOUNTS_JSON` config loader and the filename helpers (`makeFileName` / `parseFileName`).
+**`brokers/`** — Per-broker plugins. Each plugin exports `subject(accountId, date)` (the IMAP `SUBJECT` search string for that broker's contract-note emails) and `extract(text)` (returns `{ payin_payout_obligation, net_brokerage, other_charges }` from decrypted PDF text; `total_charges` and `final_net` are derived later by `updateSheet.js`). `brokers/index.js` is the registry plus the `BROKER_ACCOUNTS_JSON` config loader and the filename helpers (`makeFileName` / `parseFileName`).
 
 **`fetchMail.js`** — Loads `BROKER_ACCOUNTS_JSON`, opens **one IMAP connection per email**, then iterates the broker accounts inside that mailbox. For each account it runs the broker-specific subject search, saves attachments as `<safeEmail>__<broker>__<accountId>__<originalName>.pdf`, and decrypts via the system `qpdf` binary using `pdfPassword` from the same account entry.
 
@@ -82,7 +82,7 @@ A single env var holds a JSON array of mailboxes. Each mailbox has one Gmail log
 | 1 | `E` | `net_brokerage` |
 | 2 | `F` | `other_charges` |
 | 3 | `G` | `total_charges` (= `net_brokerage + other_charges`, computed by `updateSheet.js`) |
-| 4 | `H` | `final_net` |
+| 4 | `H` | `final_net` (= `payin_payout_obligation - total_charges`, computed by `updateSheet.js`) |
 
 Columns A–C are reserved for serial number / day name / formatted date. Pick `sheetStartColumn` for each account so the per-account 5-column blocks don't overlap; gaps between blocks (and any cells with formulas) are preserved from the previous row via `PASTE_FORMULA`.
 

--- a/checkDates.js
+++ b/checkDates.js
@@ -14,8 +14,8 @@ const MONTHS = {
 };
 
 function parseDateCell(str) {
-  // Parses "01-May-25" or "1-May-25" → UTC midnight Date
-  const [dd, mon, yy] = str.split("-");
+  // Handles both "26 May 26" (space-separated, written by updateSheet.js) and "01-May-25" (dash-separated)
+  const [dd, mon, yy] = str.split(/[\s-]+/);
   const month = MONTHS[mon];
   if (month === undefined) throw new Error(`Unknown month abbreviation: "${mon}"`);
   return new Date(Date.UTC(2000 + parseInt(yy, 10), month, parseInt(dd, 10)));

--- a/tests/checkDates.test.js
+++ b/tests/checkDates.test.js
@@ -6,6 +6,11 @@ describe("parseDateCell()", () => {
     expect(d.toISOString().slice(0, 10)).toBe("2025-04-30");
   });
 
+  test("parses space-separated format written by updateSheet.js", () => {
+    const d = parseDateCell("26 May 26");
+    expect(d.toISOString().slice(0, 10)).toBe("2026-05-26");
+  });
+
   test("handles single-digit day", () => {
     const d = parseDateCell("1-May-25");
     expect(d.toISOString().slice(0, 10)).toBe("2025-05-01");

--- a/tests/updateSheet.test.js
+++ b/tests/updateSheet.test.js
@@ -35,13 +35,14 @@ describe("letterToColumn()", () => {
 });
 
 describe("buildAccountValues()", () => {
-  test("returns four numbers from a full match", () => {
+  test("returns five values [payin, brokerage, other, total, final] from a full match", () => {
     const vals = buildAccountValues({
       payin_payout_obligation: 100,
       net_brokerage: 20,
       other_charges: 5,
     });
-    expect(vals).toEqual([100, 20, 5, 25]);
+    // total = 20 + 5 = 25; final = payin - total = 100 - 25 = 75
+    expect(vals).toEqual([100, 20, 5, 25, 75]);
   });
 
   test("totalCharges = net_brokerage + other_charges", () => {
@@ -53,16 +54,27 @@ describe("buildAccountValues()", () => {
     expect(total).toBe(brokerage + other);
   });
 
+  test("final_net = payin - total_charges", () => {
+    const [payin, , , total, finalNet] = buildAccountValues({
+      payin_payout_obligation: -9275.75,
+      net_brokerage: 160,
+      other_charges: 579.36,
+    });
+    expect(finalNet).toBeCloseTo(payin - total, 2);
+    expect(finalNet).toBeCloseTo(-10015.11, 2);
+  });
+
   test("defaults all to zero when match is undefined", () => {
-    expect(buildAccountValues(undefined)).toEqual([0, 0, 0, 0]);
+    expect(buildAccountValues(undefined)).toEqual([0, 0, 0, 0, 0]);
   });
 
   test("defaults all to zero when match is null", () => {
-    expect(buildAccountValues(null)).toEqual([0, 0, 0, 0]);
+    expect(buildAccountValues(null)).toEqual([0, 0, 0, 0, 0]);
   });
 
   test("handles missing fields with zero fallback", () => {
     const vals = buildAccountValues({ payin_payout_obligation: 50 });
-    expect(vals).toEqual([50, 0, 0, 0]);
+    // total = 0; final = 50 - 0 = 50
+    expect(vals).toEqual([50, 0, 0, 0, 50]);
   });
 });

--- a/updateSheet.js
+++ b/updateSheet.js
@@ -27,14 +27,15 @@ function letterToColumn(letter) {
   return col;
 }
 
-const ACCOUNT_COLUMN_COUNT = 4;
+const ACCOUNT_COLUMN_COUNT = 5;
 
 function buildAccountValues(match) {
   const payin = match?.payin_payout_obligation ?? 0;
   const brokerage = match?.net_brokerage ?? 0;
   const other = match?.other_charges ?? 0;
   const totalCharges = brokerage + other;
-  return [payin, brokerage, other, totalCharges];
+  const finalNet = payin - totalCharges;
+  return [payin, brokerage, other, totalCharges, finalNet];
 }
 
 const sheetsRetryOpts = {


### PR DESCRIPTION
## Summary

Follow-up to #20 (merged). Fixes two data-correctness bugs discovered while reviewing the live sheet.

## Bug 1 — `final_net` was never written to the sheet

`updateSheet.js` documented a 5-column block per account ending in `final_net`, but `ACCOUNT_COLUMN_COUNT` was `4` and `buildAccountValues()` returned only `[payin, brokerage, other, total]`. The 5th column (final net) was never populated by the pipeline — it relied on a stale sheet formula, which left those columns frozen at constant values across every row (`-1038.88` for Angel One, `-1150.26` for Finvasia).

**Fix:** `ACCOUNT_COLUMN_COUNT` → `5`; `buildAccountValues()` now appends `final_net = payin_payout_obligation − total_charges`, writing the correct per-day final net for every account using the unified layout `[payin, brokerage, other, total, final]`.

Verified against the sample contract notes:
- Angel One: `-3569 − 436.53 = -4005.53` ✓ (matches PDF)
- Finvasia: `-9275.75 − 739.36 = -10015.11` ✓ (matches PDF)

> **Action required in the sheet:** the Finvasia block columns `L`/`M` should be relabeled — `L` = **Total Charges**, `M` = **Final Net** — to match this unified layout.

## Bug 2 — `checkDates.js` crashed on the sheet's date format

`updateSheet.js` writes dates as `"26 May 26"` (space-separated), but `parseDateCell()` split only on `-`, producing `Unknown month abbreviation: "undefined"` and exiting `check-dates` with code 1.

**Fix:** split on `/[\s-]+/` so both space- and dash-separated formats parse. Added a regression test.

## Other
- `CLAUDE.md`: documents `final_net` as computed by `updateSheet.js`, and corrects the broker `extract()` return description (`other_charges`, not `final_net`).

## Tests
All 79 tests pass, including new regression tests pinning `final_net = payin − total_charges` against known PDF values and the space-separated date format.

https://claude.ai/code/session_01Hcdya6TXHn6QjqGXqF3mBC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hcdya6TXHn6QjqGXqF3mBC)_